### PR TITLE
Add repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,9 @@
     "svgo": "^0.5.1"
   },
   "devDependencies": {
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mrsum/webpack-svgstore-plugin"
   }
 }


### PR DESCRIPTION
Adding repo information to `package.json` will add a link back to the repo from npm: https://www.npmjs.com/package/webpack-svgstore-plugin