### PR TITLE
Использовать glob-паттерны для указания списка исходных файлов.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ module.exports = {
     app: path.join(_path, 'platform', 'static', 'js', 'index.js'),
   },
   plugins: [
-    new SvgStore(path.join(sourcePath, 'svg'), path.join(distPath, 'svg'), {
+    new SvgStore(path.join(sourcePath, 'svg', '**/*.svg'), path.join(distPath, 'svg'), {
       name: 'svg/[hash].sprite.svg',
       chunk: 'app'
     })

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ var _options = {
 var _ = require('lodash');
 var fs = require('fs');
 var path = require('path');
-var walk = require('walk');
+var glob = require('glob');
 var jade = require('jade');
 var parse = require('htmlparser2');
 var utils = require('./helpers/utils');
@@ -45,17 +45,25 @@ var WebpackSvgStore = function(input, output, options) {
  * @return {array}        Array of paths
  */
 WebpackSvgStore.prototype.filesMap = function(input, cb) {
-  var files = [];
-  var walker = walk.walk(input, { followLinks: true });
-
-  walker.on('file', function(root, stat, next) {
-    files.push(root + '/' + stat.name);
-    next();
-  });
-
-  walker.on('end', function() {
+  // in case if array was passed
+  if (input instanceof Array) {
+    var files = [];
+    input.forEach(function(input) {
+      this.filesMap(input, function(fileList) {
+        files = files.concat(fileList);
+      });
+    });
+    console.log(files);
     cb(files);
-  });
+  } else {
+    glob(input, function(error, fileList) {
+      if (error) {
+        throw error;
+      }
+      // slice off pattern
+      cb(fileList.slice(1));
+    });
+  }
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "glob": "^6.0.1",
     "htmlparser2": "^3.8.3",
     "jade": "^1.11.0",
     "lodash": "^3.10.1",
-    "svgo": "^0.6.0",
-    "walk": "^2.3.9"
+    "svgo": "^0.6.0"
   },
   "devDependencies": {
     "chai": "^3.4.1",


### PR DESCRIPTION
Хотелось бы иметь возможность указывать glob-паттерны для списка исходных файлов, а не директорию, в которой волком происходит обход. Плюс это поправит баг, когда сборка падает, если в директории оказываются не svg-файлы (например `.DS_Store`).