### PR TITLE
Adding baseUrl parameter to support CDN XHR

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ module.exports = {
     new SvgStore(path.join(sourcePath, 'svg', '**/*.svg'), path.join(distPath, 'svg'), {
       name: '[hash].sprite.svg',
       chunk: 'app',
+      baseUrl: '//path-to-cdn:port/'
       prefix: 'myprefix-',
       svgoOptions: {
         // options for svgo, optional
@@ -37,6 +38,8 @@ module.exports = {
 `name` - sprite name
 
 `chunk` - add xhr to etry point chunk (optional) 
+
+`baseUrl` - server where the sprites are stored, for example a CDN (optional, default: `'window.location'`)
 
 `prefix` - add prefix to svg id's (optional, default: `'icon-'`)
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ module.exports = {
 
 `chunk` - add xhr to etry point chunk (optional) 
 
-`baseUrl` - server where the sprites are stored, for example a CDN (optional, default: `'window.location'`)
+`baseUrl` - server where the sprites are stored, for example a CDN (optional, default: `'window.location'` OR window.baseUrl if set)
 
 `prefix` - add prefix to svg id's (optional, default: `'icon-'`)
 

--- a/helpers/svgxhr.js
+++ b/helpers/svgxhr.js
@@ -5,10 +5,14 @@
  * @see: https://www.npmjs.com/package/webpack-svgstore-plugin
  * @return {[type]}     [description]
  */
-function svgXHR(url) {
+function svgXHR(url, baseUrl) {
   var _ajax = new XMLHttpRequest();
-  var fullUrl = window.location.protocol + '//' + window.location.hostname + (window.location.port ? ':' + window.location.port : '');
-  _ajax.open('GET', fullUrl + url, true);
+
+  if (typeof baseUrl === 'undefined') {
+  	baseUrl = window.location.protocol + '//' + window.location.hostname + (window.location.port ? ':' + window.location.port : '');
+  }
+
+  _ajax.open('GET', baseUrl + url, true);
   _ajax.send();
   _ajax.onload = function() {
     var div = document.createElement('div');

--- a/helpers/svgxhr.js
+++ b/helpers/svgxhr.js
@@ -9,7 +9,11 @@ function svgXHR(url, baseUrl) {
   var _ajax = new XMLHttpRequest();
 
   if (typeof baseUrl === 'undefined') {
-  	baseUrl = window.location.protocol + '//' + window.location.hostname + (window.location.port ? ':' + window.location.port : '');
+  	if (typeof window.baseUrl !== 'undefined') {
+  		baseUrl = window.baseUrl;
+  	} else {
+  		baseUrl = window.location.protocol + '//' + window.location.hostname + (window.location.port ? ':' + window.location.port : '');
+  	}
   }
 
   _ajax.open('GET', baseUrl + url, true);

--- a/helpers/utils.js
+++ b/helpers/utils.js
@@ -254,11 +254,15 @@ module.exports.prepareFolder = function(folder) {
 /**
  * Prepare svgXHR function
  * @param  {[type]} sprites [description]
+ * @param  {[type]} baseUrl [description]
  * @return {[type]}         [description]
  */
-module.exports.svgXHR = function(filename) {
+module.exports.svgXHR = function(filename, baseUrl) {
   var wrapper = fs.readFileSync(path.join(__dirname, 'svgxhr.js'), 'utf-8');
-  wrapper += 'svgXHR(\'' + filename + '\');';
+
+  baseUrl = (typeof baseUrl !== 'undefined') ? ', \''+ baseUrl +'\'': '';
+
+  wrapper += 'svgXHR(\'' + filename + '\''+ baseUrl +');';
   return wrapper;
 };
 

--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ WebpackSvgStore.prototype.apply = function(compiler) {
             if (chunk.name === chunkWrapper) {
               chunk.files.filter(ModuleFilenameHelpers.matchObject.bind(undefined, options)).forEach(function(file) {
                 if (/\.js?$/.test(file)) {
-                  compilation.assets[file] = new ConcatSource(utils.svgXHR(path.join(publicPath, filePath)), '\n', compilation.assets[file]);
+                  compilation.assets[file] = new ConcatSource(utils.svgXHR(path.join(publicPath, filePath), options.baseUrl), '\n', compilation.assets[file]);
                 }
               });
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-svgstore-plugin",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Webpack svgstore plugin",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When the result sprite file is not on the same host as the rest of the site, a url may be supplied to allow for a different server to be used for the XHR call.