### PR TITLE
Не создавать директорию по inputFolder

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,6 @@ WebpackSvgStore.prototype.filesMap = function(input, cb) {
       if (error) {
         throw error;
       }
-      // slice off pattern
       cb(fileList);
     });
   }

--- a/index.js
+++ b/index.js
@@ -79,7 +79,6 @@ WebpackSvgStore.prototype.apply = function(compiler) {
   var spriteName = this.options.name;
 
   // prepare input / output folders
-  utils.prepareFolder(inputFolder);
   utils.prepareFolder(outputFolder);
 
   // subscribe to webpack emit state

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-svgstore-plugin",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Webpack svgstore plugin",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
В случае если передать в качестве input'а glob-выражение `some-dir/*.svg`, то будет создана директория `some-dir/*.svg`, что не совсем хорошо.