### PR TITLE
instaniate options

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ var WebpackSvgStore = function(input, output, options) {
   // set attributes
   this.input    = input;
   this.output   = output;
-  this.options  = _.merge(_options, options);
+  this.options  = _.merge({}, _options, options);
 
   return this;
 };


### PR DESCRIPTION
Записывать переданные опции в отдельный объект, а не в общий (в пределах
замыкания) `_options`, так как если собирать несколько спрайтов, то они
будут шарить одинаковые опции.