### PR TITLE
Fix output filename when output dir is ''

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ WebpackSvgStore.prototype.apply = function(compiler) {
     self.filesMap(inputFolder, function(files) {
       var fileContent = utils.createSprite(utils.parseFiles(files, options));
       var fileName = utils.hash(fileContent, spriteName);
-      var filePath = [outputFolder, fileName].join('/');
+      var filePath = path.join(outputFolder, fileName);
 
       // fallback for windows backslashes
       var fullPath = slash(path.join(publicPath, filePath));


### PR DESCRIPTION
Using `[].join('/')` creates a filename of `/name.svg` when output is `''` (i.e. just the build dir) which can't be served by webpack dev server. This change fixes that and correctly uses the filename without the preceding slash.