### PR TITLE
Fixing Ajax requests with CORS (IE9)

### DIFF
--- a/helpers/svgxhr.js
+++ b/helpers/svgxhr.js
@@ -8,6 +8,10 @@
 function svgXHR(url, baseUrl) {
   var _ajax = new XMLHttpRequest();
 
+  if (typeof XDomainRequest !== 'undefined') {
+    _ajax = new XDomainRequest();
+  }
+
   if (typeof baseUrl === 'undefined') {
     if (typeof window.baseUrl !== 'undefined') {
       baseUrl = window.baseUrl;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-svgstore-plugin",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "Webpack svgstore plugin",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
IE9/IE8 force you to use XDomainRequest, otherwise an "Access Denied" error is thrown. 