### PR TITLE
Fixing svgxhr for IE10

### DIFF
--- a/helpers/svgxhr.js
+++ b/helpers/svgxhr.js
@@ -21,10 +21,14 @@ function svgXHR(url, baseUrl) {
   }
 
   _ajax.open('GET', baseUrl + url, true);
-  _ajax.send();
+
+  _ajax.onprogress = function(){};
+
   _ajax.onload = function() {
     var div = document.createElement('div');
     div.innerHTML = _ajax.responseText;
     document.body.insertBefore(div, document.body.childNodes[0]);
   };
+
+  _ajax.send();
 }


### PR DESCRIPTION
IE9 introduced an XDomainRequest regression where if no 'progress' callback is specified it will randomly cancel the request.

IE10 doesn't properly load SVG's without the timeout.

:facepalm: