### PR TITLE
Proper parameters to document.addEventListener

### DIFF
--- a/helpers/utils.js
+++ b/helpers/utils.js
@@ -282,7 +282,7 @@ module.exports.svgXHR = function(filename, baseUrl) {
 
   baseUrl = (typeof baseUrl !== 'undefined') ? ', \''+ baseUrl +'\'': '';
 
-  wrapper += 'document.addEventListener(\'DOMContentLoaded\', svgXHR(\'' + filename + '\''+ baseUrl +'), false);';
+  wrapper += 'document.addEventListener(\'DOMContentLoaded\', function(){ svgXHR(\'' + filename + '\''+ baseUrl +'); }, false);';
   return wrapper;
 };
 


### PR DESCRIPTION
Close #75

According to MDN:

- target.addEventListener(type, listener[, useCapture]);
- listener
The object that receives a notification when an event of the specified type occurs. This must be an object implementing the EventListener interface, or simply a JavaScript function.