### PR TITLE
Use new ConcatSource dependency for webpack 2.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,8 +19,14 @@ var path = require('path');
 var url = require('url');
 var slash = require('slash');
 var utils = require('./helpers/utils');
-var ConcatSource = require('webpack/lib/ConcatSource');
 var ModuleFilenameHelpers = require('webpack/lib/ModuleFilenameHelpers');
+
+var ConcatSource;
+try {
+  ConcatSource = require('webpack/lib/ConcatSource');       // webpack 1.x
+} catch (e) {
+  ConcatSource = require('webpack-sources').ConcatSource;   // webpack 2.x
+}
 
 /**
  * Constructor

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "jade": "^1.11.0",
     "lodash": "^3.10.1",
     "slash": "^1.0.0",
-    "svgo": "^0.6.0"
+    "svgo": "^0.6.0",
+    "webpack-sources": "^0.1.2"
   },
   "devDependencies": {
     "chai": "^3.4.1",


### PR DESCRIPTION
I can't say that this gives full compatibility with webpack 2.x (I haven't tried every feature yet), but getting the sprite to build only required this small change. Should help with #71