### PR TITLE
Added xmlns:xlink attribute to result svg

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
 var _options = {
   svg: {
     xmlns: 'http://www.w3.org/2000/svg',
+    'xmlns:xlink': 'http://www.w3.org/1999/xlink',
     style: 'position:absolute; width: 0; height: 0'
   },
   loop: 2,


### PR DESCRIPTION
Firefox gives an error 'prefix not bound to a namespace' without this attribute.