### PR TITLE
Use url as is when it starts from http

### DIFF
--- a/src/helpers/svgxhr.js
+++ b/src/helpers/svgxhr.js
@@ -28,8 +28,12 @@ var svgXHR = function(options) {
       baseUrl = window.location.protocol + '//' + window.location.hostname + (window.location.port ? ':' + window.location.port : '');
     }
   }
+  if (url.indexOf('http') === 0) {
+    _fullPath = url.replace(/([^:]\/)\/+/g, '$1');
+  } else {
+    _fullPath = (baseUrl + '/' + url).replace(/([^:]\/)\/+/g, '$1');
+  }
 
-  _fullPath = (baseUrl + '/' + url).replace(/([^:]\/)\/+/g, '$1');
   _ajax.open('GET', _fullPath, true);
   _ajax.onprogress = function() {};
   _ajax.onload = function() {


### PR DESCRIPTION
Maybe code is ugly but it's allow to add webpack public path to filename dynamically like this:
```javascript
const __svg__ = { path: '../../icons/frontend/*.svg', name: 'icons/sprite.svg' };
__svg__.filename = __webpack_public_path__ + __svg__.filename;
require('webpack-svgstore-plugin/src/helpers/svgxhr')(__svg__);
```
Default request was:
`http://rgb-lab.dev/icons/sprite.svg`
I need request to:
`http://rgb-lab.dev:3000/public/web/icons/sprite.svg`
My public path is:
`/public/web/`
Before modifications and with using `__webpack_public_path__` I have request to:
`http://rgb-lab.dev/http://rgb-lab.dev:3000/public/web/icons/sprite.svg`