### PR TITLE
XHRHelper - Add check for SVG response

### DIFF
--- a/src/helpers/svgxhr.js
+++ b/src/helpers/svgxhr.js
@@ -33,6 +33,9 @@ var svgXHR = function(options) {
   _ajax.open('GET', _fullPath, true);
   _ajax.onprogress = function() {};
   _ajax.onload = function() {
+    if(!_ajax.responseText || _ajax.responseText.substr(0, 4) !== "<svg") {
+      throw Error("Invalid SVG Response");
+    }
     var div = document.createElement('div');
     div.innerHTML = _ajax.responseText;
     document.body.insertBefore(div, document.body.childNodes[0]);


### PR DESCRIPTION
Since `innerHTML` is currently used unsanitized, it is possible to execute arbitrary Javascript from the the response returned from the AJAX request. This *might* be a trusted URL, but there is no guarantee of it's validity.

Added a check to ensure an `<svg>` element is returned in the AJAX response to prevent XSS attacks