### PR TITLE
Fix issue with defs id duplications

### DIFF
--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -119,7 +119,6 @@ var _defs = function(id, dom, data) {
       }
 
       if (child && child.children && child.children.length > 0) {
-        data.push(child);
         parseChilds(child.children, data);
       }
 


### PR DESCRIPTION
There is an issue with id defs duplication, for example we have svg with defs like:
```
<defs>
    <linearGradient x1="30%" y1="-6%" x2="55%" y2="92%" id="linearGradient-1">
            <stop stop-color="#006884" offset="0%"></stop>
            <stop stop-color="#8AD1D0" offset="100%"></stop>
    </linearGradient>
</defs>
```

Аfter we create svg sprite in result it create two linearGradients with equal id