### PR TITLE
Accept http code 0 when fetching the svg file

### DIFF
--- a/src/helpers/svgxhr.js
+++ b/src/helpers/svgxhr.js
@@ -36,7 +36,7 @@ var svgXHR = function(options) {
     if(!_ajax.responseText || _ajax.responseText.substr(0, 4) !== "<svg") {
       throw Error("Invalid SVG Response");
     }
-    if(_ajax.status < 200 || _ajax.status >= 300) {
+    if(_ajax.status < 200 || _ajax.status >= 300 || _ajax.status === 0) {
       return;
     }
     var div = document.createElement('div');

--- a/src/helpers/svgxhr.js
+++ b/src/helpers/svgxhr.js
@@ -36,7 +36,7 @@ var svgXHR = function(options) {
     if(!_ajax.responseText || _ajax.responseText.substr(0, 4) !== "<svg") {
       throw Error("Invalid SVG Response");
     }
-    if(_ajax.status < 200 || _ajax.status >= 300 || _ajax.status === 0) {
+    if((_ajax.status < 200 || _ajax.status >= 300) && _ajax.status !== 0) {
       return;
     }
     var div = document.createElement('div');


### PR DESCRIPTION
In some cases, for instance in an iOS cordova app, the ajax status code returned is 0, so this code must be white listed when fetching the svg store file