### PR TITLE
Allow passing path and name to plugin instead of in the function mark

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Use webpack-svgstore-plugin@4.x.x for Webpack 2.x.x
 #### 1) require plugin
 ```javascript
 //webpack.config.js
+var path = require('path');
 var SvgStore = require('webpack-svgstore-plugin');
 module.exports = {
   plugins: [
@@ -53,7 +54,8 @@ module.exports = {
           { removeTitle: true }
         ]
       },
-      prefix: 'icon'
+      prefix: 'icon',
+      path: path.join(__dirname, '../src/assets/**/*.svg')
     })
   ]
 }
@@ -98,6 +100,8 @@ React JSX:
 #### options
 - `template` - add custom jade template layout (optional)
 - `svgoOptions` - options for [svgo](https://github.com/svg/svgo) (optional, default: `{}`)
+- `path` - absolute path to SVG files (optional, default: your function mark path or `/**/*.svg`)
+- `name` - name of the resulting file (optional, default: your function mark name or `[hash].sprite.svg`)
 
 
 ## License

--- a/src/svgstore.js
+++ b/src/svgstore.js
@@ -32,6 +32,10 @@ class WebpackSvgStore {
   constructor(options) {
     this.tasks = {};
     this.options = _.merge({}, defaults, options);
+
+    if (this.options.path && !path.isAbsolute(this.options.path)) {
+      throw new Error('[webpack-svgstore-plugin] Validation Error: path should be absolute when passed as plugin option')
+    }
   };
 
   addTask(file, value) {
@@ -43,9 +47,9 @@ class WebpackSvgStore {
 
   createTaskContext(expr, parser) {
     const data = {
-      path: '/**/*.svg',
-      fileName: '[hash].sprite.svg',
-      context: parser.state.current.context
+      path: this.options.path || '/**/*.svg',
+      fileName: this.options.name || '[hash].sprite.svg',
+      context: this.options.path ? '' : parser.state.current.context
     };
 
     expr.init.properties.forEach(function (prop) {
@@ -73,10 +77,10 @@ class WebpackSvgStore {
   apply(compiler) {
     // AST parser
     compiler.plugin('compilation', (compilation, data) => {
-      
+
       compilation.dependencyFactories.set(ConstDependency, new NullFactory());
       compilation.dependencyTemplates.set(ConstDependency, new ConstDependency.Template());
-      
+
       data.normalModuleFactory.plugin('parser', (parser, options) => {
         parser.plugin('statement', (expr) => {
           if (!expr.declarations || !expr.declarations.length) return;


### PR DESCRIPTION
In our current setup, it is not possible for us to determine the path to the SVG files in a "browser" environment (from where the function mark lives). But we can from our webpack config file, so I've added a way to pass in both `path` and `name` directly to the plugin. If provided, they'll be used over the default, but can still be overwrited by the function mark - if that make sense. Because the context is set to where the function mark live, if passing the path directly to the plugin, it must be absolute and the context will be switch to an empty string.