### PR TITLE
Restore many variable for options and fix webpack build error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ coverage/
 platform/dist/
 platform/static/min/
 sprites/
+.idea/
 *.log
 *.lock

--- a/platform/global.js
+++ b/platform/global.js
@@ -19,7 +19,7 @@ module.exports = function(_path) {
       publicPath: '/platform/'
     },
     resolve: {
-      extensions: ['', '.js'],
+      extensions: ['.js']
     },
     plugins: [
       // create svgStore instance object

--- a/src/svgstore.js
+++ b/src/svgstore.js
@@ -81,7 +81,13 @@ class WebpackSvgStore {
         parser.plugin('statement', (expr) => {
           if (!expr.declarations || !expr.declarations.length) return;
           const thisExpr = expr.declarations[0];
-          if (thisExpr.id.name === "__svg__") {
+          if ([
+            '__svg__',
+            '__sprite__',
+            '__svgstore__',
+            '__svgsprite__',
+            '__webpack_svgstore__'
+          ].indexOf(thisExpr.id.name) > -1) {
             return this.createTaskContext(thisExpr, parser);
           }
         });


### PR DESCRIPTION
Вернул возможность использования переменных из документации. Сейчас работает только одна из них - `__svg__` 
И еще починил `build` у внутреннего сборщика