### PR TITLE
Fixes DOM access before it is ready

### DIFF
--- a/src/helpers/svgxhr.js
+++ b/src/helpers/svgxhr.js
@@ -41,7 +41,10 @@ var svgXHR = function(options) {
     }
     var div = document.createElement('div');
     div.innerHTML = _ajax.responseText;
-    document.body.insertBefore(div, document.body.childNodes[0]);
+    
+    document.addEventListener('DOMContentLoaded', function() {
+      document.body.insertBefore(div, document.body.childNodes[0]);
+    });
   };
   _ajax.send();
 };


### PR DESCRIPTION
Adding [DOMContentLoaded](https://developer.mozilla.org/en-US/docs/Web/Events/DOMContentLoaded) listener before adding the div sprite to the DOM.

When your script is loaded in the `<head>` of the document, `<body>` isn't accessible yet, so this is necessary.