### PR TITLE
Optional defs splitting

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ module.exports = {
           { removeTitle: true }
         ]
       },
+      splitDefs: true,
       prefix: 'icon'
     })
   ]
@@ -97,6 +98,8 @@ React JSX:
 
 #### options
 - `template` - add custom jade template layout (optional)
+- `prefix` - prefix all icons with name (optional, default: `icon-`)
+- `splitDefs` - split defs from symbols (optional, default: true)
 - `svgoOptions` - options for [svgo](https://github.com/svg/svgo) (optional, default: `{}`)
 
 

--- a/package.json
+++ b/package.json
@@ -5,9 +5,11 @@
   "main": "src/svgstore.js",
   "scripts": {
     "test": "NODE_ENV=platform ./node_modules/.bin/_mocha ./src/__tests__/index.js",
+    "test-windows": "SET NODE_ENV=platform&& .\\node_modules\\.bin\\_mocha .\\src\\__tests__\\index.js",
     "code:coverage": "NODE_ENV=platform ./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha ./src/__tests__/index.js && npm run code:report",
     "code:report": "CODECLIMATE_REPO_TOKEN=29b2c943849c33562af12b70563d86e95c073e04c7510e9da5d9711cf3233b17 ./node_modules/.bin/codeclimate-test-reporter < coverage/lcov.info",
-    "build": "rm -rf platform/dist/* && NODE_ENV=platform webpack --progress --colors --bail"
+    "build": "rm -rf platform/dist/* && NODE_ENV=platform webpack --progress --colors --bail",
+    "build-windows": "if exist platform\\dist (rmdir /s /q platform\\dist) && SET NODE_ENV=platform&& webpack --progress --colors --bail"
   },
   "author": "me@mrsum.ru",
   "contributors": [

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -103,6 +103,7 @@ describe('utils.createSprite', function() {
     loop: 2,
     svgoOptions: {},
     prefix: 'icon-',
+    splitDefs: true,
     name: 'sprite.[hash].svg',
     ajaxWrapper: false,
     template: path.join(__dirname, '..', 'templates/layout.pug')

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -163,7 +163,11 @@ const _symbols = function(id, dom, data, options) {
 
   // add dom children without defs and titles
   symbol.children = _.filter(dom.children, function(obj) {
-    return (options.splitDefs && obj.name !== 'defs') && obj.name !== 'title';
+    if (options.splitDefs) {
+      return obj.name !== 'defs' && obj.name !== 'title';
+    }
+
+    return obj.name !== 'title';
   });
 
   // go through the svg element

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -143,14 +143,14 @@ const _defs = function(id, dom, data) {
  * @param  {[type]} data [description]
  * @return {[type]}      [description]
  */
-const _symbols = function(id, dom, data, prefix) {
+const _symbols = function(id, dom, data, options) {
   // create symbol object
   const symbol = {
     type: 'tag',
     name: 'symbol',
     attribs: {
       viewBox: dom.attribs.viewBox,
-      id: prefix + id
+      id: options.prefix + id
     },
     next: null,
     prev: null,
@@ -159,7 +159,7 @@ const _symbols = function(id, dom, data, prefix) {
 
   // add dom children without defs and titles
   symbol.children = _.filter(dom.children, function(obj) {
-    return obj.name !== 'defs' && obj.name !== 'title';
+    return (options.splitDefs && obj.name !== 'defs') && obj.name !== 'title';
   });
 
   // go through the svg element
@@ -207,11 +207,14 @@ const _filesMapSync = function(input) {
  * @param  {[type]} dom [description]
  * @return {[type]}     [description]
  */
-const _parseDomObject = function(data, filename, dom, prefix) {
+const _parseDomObject = function(data, filename, dom, options) {
   const id = _convertFilenameToId(filename);
   if (dom && dom[0]) {
-    _defs(id, dom[0], data.defs);
-    _symbols(id, dom[0], data.symbols, prefix);
+    if(options.splitDefs) {
+      _defs(id, dom[0], data.defs);
+    }
+
+    _symbols(id, dom[0], data.symbols, options);
   }
 
   return data;
@@ -257,7 +260,7 @@ const _parseFiles = function(files, options) {
 
     const handler = new parse.DomHandler(function(error, dom) {
       if (error) self.log(error);
-      else data = _parseDomObject(data, filename, dom, options.prefix);
+      else data = _parseDomObject(data, filename, dom, options);
     });
 
     // lets create parser instance

--- a/src/svgstore.js
+++ b/src/svgstore.js
@@ -9,6 +9,7 @@ const defaults = {
   svgoOptions: {},
   name: 'sprite.[hash].svg',
   prefix: 'icon-',
+  splitDefs: true,
   template: __dirname + '/templates/layout.pug'
 };
 


### PR DESCRIPTION
By default this package splits all `<defs/>` from an SVG file into the global SVG sprite sheet.

Firefox is having trouble with SVG filters when they are not contained within the used symbol. Therefore I would like to have an option to disable this behaviour.